### PR TITLE
feat(skills): add library selection and pagination

### DIFF
--- a/src/i18n/locales/en-us.ts
+++ b/src/i18n/locales/en-us.ts
@@ -331,6 +331,12 @@ const enUS = {
 			selectAll: "Select all skills",
 			selectNamed: "Select {{name}}",
 			deleteSelected: "Delete selected skills",
+			pagination: {
+				label: "Skill pagination",
+				summary: "{{start}} to {{end}} of {{total}} results",
+				previous: "Previous",
+				next: "Next",
+			},
 			gitDialog: {
 				title: "Import from Git URL",
 				description:

--- a/src/i18n/locales/en-us.ts
+++ b/src/i18n/locales/en-us.ts
@@ -328,6 +328,9 @@ const enUS = {
 			mount: "Mount",
 			update: "Update",
 			updateNamed: "Update {{name}}",
+			selectAll: "Select all skills",
+			selectNamed: "Select {{name}}",
+			deleteSelected: "Delete selected skills",
 			gitDialog: {
 				title: "Import from Git URL",
 				description:

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -317,6 +317,9 @@ const zhCN = {
 			mount: "挂载",
 			update: "更新",
 			updateNamed: "更新 {{name}}",
+			selectAll: "选择全部技能",
+			selectNamed: "选择 {{name}}",
+			deleteSelected: "删除已选技能",
 			gitDialog: {
 				title: "从 Git 链接导入",
 				description: "仓库根目录需要包含有效的 SKILL.md，导入后可从远程更新",

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -320,6 +320,12 @@ const zhCN = {
 			selectAll: "选择全部技能",
 			selectNamed: "选择 {{name}}",
 			deleteSelected: "删除已选技能",
+			pagination: {
+				label: "技能分页",
+				summary: "{{start}} 至 {{end}}，共 {{total}} 条结果",
+				previous: "上一页",
+				next: "下一页",
+			},
 			gitDialog: {
 				title: "从 Git 链接导入",
 				description: "仓库根目录需要包含有效的 SKILL.md，导入后可从远程更新",

--- a/src/pages/skills/components/skill-library-table.test.tsx
+++ b/src/pages/skills/components/skill-library-table.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SkillLibraryTable } from "./skill-library-table";
+
+const SKILLS = [
+	{
+		id: "skill-1",
+		folderName: "repository-map",
+		displayName: "Repository Map",
+		description: "Maps repository structure.",
+		sourceType: "local_folder" as const,
+		sourcePath: "/tmp/repository-map",
+		createdAtMs: 1,
+		updatedAtMs: 1,
+		accessLabel: "读取",
+		mountedCount: 0,
+		name: "repository-map",
+		sourceLabel: "文件导入",
+	},
+];
+
+describe("SkillLibraryTable", () => {
+	it("reveals the delete action after a Skill is selected", async () => {
+		const user = userEvent.setup();
+		render(
+			<SkillLibraryTable
+				isUpdatePending={false}
+				onManageSkill={vi.fn()}
+				onUpdateSkill={vi.fn()}
+				skills={SKILLS}
+				status={null}
+			/>,
+		);
+
+		expect(screen.queryByLabelText("删除已选技能")).not.toBeInTheDocument();
+
+		await user.click(
+			screen.getByRole("checkbox", { name: /^选择 repository-map/ }),
+		);
+
+		expect(screen.getByLabelText("删除已选技能")).toBeInTheDocument();
+	});
+});

--- a/src/pages/skills/components/skill-library-table.test.tsx
+++ b/src/pages/skills/components/skill-library-table.test.tsx
@@ -60,6 +60,22 @@ describe("SkillLibraryTable", () => {
 		expect(screen.getByLabelText("删除已选技能")).toBeInTheDocument();
 	});
 
+	it("hides pagination while all Skills fit on the first page", () => {
+		render(
+			<SkillLibraryTable
+				isUpdatePending={false}
+				onManageSkill={vi.fn()}
+				onUpdateSkill={vi.fn()}
+				skills={PAGINATED_SKILLS.slice(0, 8)}
+				status={null}
+			/>,
+		);
+
+		expect(
+			screen.queryByRole("navigation", { name: "技能分页" }),
+		).not.toBeInTheDocument();
+	});
+
 	it("moves through Skill pages eight rows at a time", async () => {
 		const user = userEvent.setup();
 		render(

--- a/src/pages/skills/components/skill-library-table.test.tsx
+++ b/src/pages/skills/components/skill-library-table.test.tsx
@@ -20,6 +20,24 @@ const SKILLS = [
 	},
 ];
 
+const PAGINATED_SKILLS = [
+	"alpha",
+	"beta",
+	"gamma",
+	"delta",
+	"epsilon",
+	"zeta",
+	"eta",
+	"theta",
+	"iota",
+].map((name, index) => ({
+	...SKILLS[0],
+	id: `skill-${index + 1}`,
+	folderName: name,
+	displayName: name,
+	name,
+}));
+
 describe("SkillLibraryTable", () => {
 	it("reveals the delete action after a Skill is selected", async () => {
 		const user = userEvent.setup();
@@ -40,5 +58,28 @@ describe("SkillLibraryTable", () => {
 		);
 
 		expect(screen.getByLabelText("删除已选技能")).toBeInTheDocument();
+	});
+
+	it("moves through Skill pages eight rows at a time", async () => {
+		const user = userEvent.setup();
+		render(
+			<SkillLibraryTable
+				isUpdatePending={false}
+				onManageSkill={vi.fn()}
+				onUpdateSkill={vi.fn()}
+				skills={PAGINATED_SKILLS}
+				status={null}
+			/>,
+		);
+
+		expect(screen.getByText("alpha")).toBeInTheDocument();
+		expect(screen.queryByText("iota")).not.toBeInTheDocument();
+		expect(screen.getByText("1 至 8，共 9 条结果")).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "下一页" }));
+
+		expect(screen.queryByText("alpha")).not.toBeInTheDocument();
+		expect(screen.getByText("iota")).toBeInTheDocument();
+		expect(screen.getByText("9 至 9，共 9 条结果")).toBeInTheDocument();
 	});
 });

--- a/src/pages/skills/components/skill-library-table.tsx
+++ b/src/pages/skills/components/skill-library-table.tsx
@@ -214,7 +214,7 @@ const SkillLibraryTable = ({
 				</Table.Content>
 			</Table.ScrollContainer>
 			{!status && skills.length > 0 ? (
-				<Table.Footer>
+				<Table.Footer className="py-xs">
 					<Pagination aria-label={t("skills.pagination.label")} size="sm">
 						<Pagination.Summary>
 							{t("skills.pagination.summary", {

--- a/src/pages/skills/components/skill-library-table.tsx
+++ b/src/pages/skills/components/skill-library-table.tsx
@@ -213,7 +213,7 @@ const SkillLibraryTable = ({
 					</Table.Body>
 				</Table.Content>
 			</Table.ScrollContainer>
-			{!status && skills.length > 0 ? (
+			{!status && skills.length > ROWS_PER_PAGE ? (
 				<Table.Footer className="py-xs">
 					<Pagination aria-label={t("skills.pagination.label")} size="sm">
 						<Pagination.Summary>

--- a/src/pages/skills/components/skill-library-table.tsx
+++ b/src/pages/skills/components/skill-library-table.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Puzzle, TrashBin } from "@gravity-ui/icons";
-import { Checkbox, type Selection, Table } from "@heroui/react";
+import { Checkbox, Pagination, type Selection, Table } from "@heroui/react";
 import { useTranslation } from "react-i18next";
 import type { Skill } from "@/types/skill";
 
@@ -36,8 +36,10 @@ const STATUS_TRANSLATION_KEYS = {
 	loading: "skills.loading",
 } as const;
 
+const ROWS_PER_PAGE = 8;
+
 /**
- * Owns the Skill Library's HeroUI table markup while the page retains data orchestration.
+ * Keeps eight-row pagination with the HeroUI table while the page retains data orchestration.
  *
  * @example
  * <SkillLibraryTable skills={skills} status={null} onManageSkill={manage} onUpdateSkill={update} isUpdatePending={false} />
@@ -51,8 +53,16 @@ const SkillLibraryTable = ({
 }: SkillLibraryTableProps) => {
 	const { t } = useTranslation();
 	const [selectedKeys, setSelectedKeys] = useState<Selection>(new Set());
+	const [page, setPage] = useState(1);
 	const hasSelectedSkills =
 		selectedKeys === "all" ? skills.length > 0 : selectedKeys.size > 0;
+	const totalPages = Math.max(1, Math.ceil(skills.length / ROWS_PER_PAGE));
+	const currentPage = Math.min(page, totalPages);
+	const pages = Array.from({ length: totalPages }, (_, index) => index + 1);
+	const startIndex = (currentPage - 1) * ROWS_PER_PAGE;
+	const paginatedSkills = skills.slice(startIndex, startIndex + ROWS_PER_PAGE);
+	const rangeStart = startIndex + 1;
+	const rangeEnd = Math.min(currentPage * ROWS_PER_PAGE, skills.length);
 
 	return (
 		<Table className="-mx-4 mt-[22px] sm:mx-0">
@@ -102,7 +112,7 @@ const SkillLibraryTable = ({
 						</Table.Column>
 					</Table.Header>
 					<Table.Body>
-						{skills.map((skill) => (
+						{paginatedSkills.map((skill) => (
 							<Table.Row className="h-24" id={skill.id} key={skill.id}>
 								<Table.Cell>
 									<Checkbox
@@ -200,6 +210,51 @@ const SkillLibraryTable = ({
 					</Table.Body>
 				</Table.Content>
 			</Table.ScrollContainer>
+			{!status && skills.length > 0 ? (
+				<Table.Footer>
+					<Pagination aria-label={t("skills.pagination.label")} size="sm">
+						<Pagination.Summary>
+							{t("skills.pagination.summary", {
+								end: rangeEnd,
+								start: rangeStart,
+								total: skills.length,
+							})}
+						</Pagination.Summary>
+						<Pagination.Content>
+							<Pagination.Item>
+								<Pagination.Previous
+									isDisabled={currentPage === 1}
+									onPress={() => setPage((value) => Math.max(1, value - 1))}
+								>
+									<Pagination.PreviousIcon />
+									{t("skills.pagination.previous")}
+								</Pagination.Previous>
+							</Pagination.Item>
+							{pages.map((pageNumber) => (
+								<Pagination.Item key={pageNumber}>
+									<Pagination.Link
+										isActive={pageNumber === currentPage}
+										onPress={() => setPage(pageNumber)}
+									>
+										{pageNumber}
+									</Pagination.Link>
+								</Pagination.Item>
+							))}
+							<Pagination.Item>
+								<Pagination.Next
+									isDisabled={currentPage === totalPages}
+									onPress={() =>
+										setPage((value) => Math.min(totalPages, value + 1))
+									}
+								>
+									{t("skills.pagination.next")}
+									<Pagination.NextIcon />
+								</Pagination.Next>
+							</Pagination.Item>
+						</Pagination.Content>
+					</Pagination>
+				</Table.Footer>
+			) : null}
 		</Table>
 	);
 };

--- a/src/pages/skills/components/skill-library-table.tsx
+++ b/src/pages/skills/components/skill-library-table.tsx
@@ -36,6 +36,7 @@ const STATUS_TRANSLATION_KEYS = {
 	loading: "skills.loading",
 } as const;
 
+/** Keeps the table scan-friendly and its page height predictable across the library. */
 const ROWS_PER_PAGE = 8;
 
 /**
@@ -57,8 +58,10 @@ const SkillLibraryTable = ({
 	const hasSelectedSkills =
 		selectedKeys === "all" ? skills.length > 0 : selectedKeys.size > 0;
 	const totalPages = Math.max(1, Math.ceil(skills.length / ROWS_PER_PAGE));
+	// Filtering can shrink the result set while a later page is active, so render the nearest valid page immediately.
 	const currentPage = Math.min(page, totalPages);
 	const pages = Array.from({ length: totalPages }, (_, index) => index + 1);
+	// The rows and footer summary share this offset to keep the visible range consistent.
 	const startIndex = (currentPage - 1) * ROWS_PER_PAGE;
 	const paginatedSkills = skills.slice(startIndex, startIndex + ROWS_PER_PAGE);
 	const rangeStart = startIndex + 1;

--- a/src/pages/skills/components/skill-library-table.tsx
+++ b/src/pages/skills/components/skill-library-table.tsx
@@ -1,5 +1,6 @@
-import { Puzzle } from "@gravity-ui/icons";
-import { Table } from "@heroui/react";
+import { useState } from "react";
+import { Puzzle, TrashBin } from "@gravity-ui/icons";
+import { Checkbox, type Selection, Table } from "@heroui/react";
 import { useTranslation } from "react-i18next";
 import type { Skill } from "@/types/skill";
 
@@ -49,6 +50,9 @@ const SkillLibraryTable = ({
 	status,
 }: SkillLibraryTableProps) => {
 	const { t } = useTranslation();
+	const [selectedKeys, setSelectedKeys] = useState<Selection>(new Set());
+	const hasSelectedSkills =
+		selectedKeys === "all" ? skills.length > 0 : selectedKeys.size > 0;
 
 	return (
 		<Table className="-mx-4 mt-[22px] sm:mx-0">
@@ -56,8 +60,20 @@ const SkillLibraryTable = ({
 				<Table.Content
 					aria-label={t("skills.libraryLabel")}
 					className="min-w-195 table-fixed"
+					onSelectionChange={setSelectedKeys}
+					selectedKeys={selectedKeys}
+					selectionMode="multiple"
 				>
 					<Table.Header>
+						<Table.Column className="w-12">
+							<Checkbox aria-label={t("skills.selectAll")} slot="selection">
+								<Checkbox.Content>
+									<Checkbox.Control>
+										<Checkbox.Indicator />
+									</Checkbox.Control>
+								</Checkbox.Content>
+							</Checkbox>
+						</Table.Column>
 						<Table.Column className="w-[48%]" isRowHeader>
 							{t("skills.columns.skill")}
 						</Table.Column>
@@ -73,11 +89,33 @@ const SkillLibraryTable = ({
 						<Table.Column
 							aria-label={t("skills.columns.actions")}
 							className="w-[13%]"
-						/>
+						>
+							{hasSelectedSkills ? (
+								<button
+									aria-label={t("skills.deleteSelected")}
+									className="ml-auto flex size-8 items-center justify-center rounded-md text-danger outline-none hover:bg-danger-soft focus-visible:ring-2 focus-visible:ring-focus-ring"
+									type="button"
+								>
+									<TrashBin aria-hidden="true" className="size-4" />
+								</button>
+							) : null}
+						</Table.Column>
 					</Table.Header>
 					<Table.Body>
 						{skills.map((skill) => (
 							<Table.Row className="h-24" id={skill.id} key={skill.id}>
+								<Table.Cell>
+									<Checkbox
+										aria-label={t("skills.selectNamed", { name: skill.name })}
+										slot="selection"
+									>
+										<Checkbox.Content>
+											<Checkbox.Control>
+												<Checkbox.Indicator />
+											</Checkbox.Control>
+										</Checkbox.Content>
+									</Checkbox>
+								</Table.Cell>
 								<Table.Cell>
 									<div className="flex items-start gap-[14px]">
 										<Puzzle
@@ -141,7 +179,7 @@ const SkillLibraryTable = ({
 							<Table.Row id="status">
 								<Table.Cell
 									className="h-24 text-center text-body-sm text-mute"
-									colSpan={5}
+									colSpan={6}
 								>
 									<span role={status === "loading" ? "status" : "alert"}>
 										{t(STATUS_TRANSLATION_KEYS[status])}
@@ -153,7 +191,7 @@ const SkillLibraryTable = ({
 							<Table.Row id="empty">
 								<Table.Cell
 									className="h-24 text-center text-body-sm text-mute"
-									colSpan={5}
+									colSpan={6}
 								>
 									{t("skills.noResults")}
 								</Table.Cell>


### PR DESCRIPTION
## Summary
- add HeroUI multi-row selection checkboxes and reveal a selected-Skill delete action
- paginate the Skill Library at eight rows per page
- hide and compact the pagination footer until a second page exists
- add localized labels and colocated interaction coverage

## Testing
- pnpm typecheck
- pnpm check
- pnpm test
- pnpm build