### PR TITLE
feat(composer): adopt shared dropdowns and update frontend budgets

### DIFF
--- a/.github/scripts/benchmark.mjs
+++ b/.github/scripts/benchmark.mjs
@@ -13,11 +13,11 @@ import { pathToFileURL } from "node:url";
 
 const BUILD_TIME_LIMIT_PERCENT = 30;
 const SIZE_LIMIT_PERCENT = 10;
-// Includes the locally bundled editor and full language catalog, with limited size headroom.
+// Includes the editor, language catalog, Markdown math, and offline fonts with limited headroom.
 // Absolute budgets prevent the allowed frontend size from growing after every merge.
 const FRONTEND_SIZE_BUDGETS = new Map([
-	["dist total (bytes)", 3_550_000],
-	["JavaScript (bytes)", 3_100_000],
+	["dist total (bytes)", 5_200_000],
+	["JavaScript (bytes)", 3_500_000],
 ]);
 
 /**

--- a/.github/scripts/benchmark.test.mjs
+++ b/.github/scripts/benchmark.test.mjs
@@ -52,8 +52,8 @@ test("editor assets fit the explicit frontend budgets", () => {
 
 test("frontend budgets accept the boundary and reject one extra byte", () => {
 	for (const [name, budget] of [
-		["dist total (bytes)", 3550000],
-		["JavaScript (bytes)", 3100000],
+		["dist total (bytes)", 5200000],
+		["JavaScript (bytes)", 3500000],
 	]) {
 		assert.equal(
 			compareMetrics({ [name]: 100 }, { [name]: budget }).failed,
@@ -88,6 +88,14 @@ test("the offline language catalog fits the frontend budgets", () => {
 	const result = compareMetrics(
 		{ "dist total (bytes)": 1649805, "JavaScript (bytes)": 1197382 },
 		{ "dist total (bytes)": 3337005, "JavaScript (bytes)": 2881164 },
+	);
+	assert.equal(result.failed, false);
+});
+
+test("Markdown math and offline fonts fit the frontend budgets", () => {
+	const result = compareMetrics(
+		{ "dist total (bytes)": 4858503, "JavaScript (bytes)": 3266113 },
+		{ "dist total (bytes)": 4860384, "JavaScript (bytes)": 3267913 },
 	);
 	assert.equal(result.failed, false);
 });

--- a/src/components/share/composer-dropdowns.tsx
+++ b/src/components/share/composer-dropdowns.tsx
@@ -1,0 +1,223 @@
+import { CircleCheckFill, Puzzle, ShieldCheck } from "@gravity-ui/icons";
+import { Dropdown, Header } from "@heroui/react";
+import { useTranslation } from "react-i18next";
+import { DropdownMenu } from "@/components/ui/dropdown-menu";
+import type { Skill } from "@/types/skill";
+import type { CreateTaskRequest } from "@/types/task";
+
+type ComposerSkillDropdownProps = {
+	/** Skills available in the library or mounted in the Workspace. */
+	availableSkills: Skill[];
+	/** Library skill IDs selected for the next Task. */
+	selectedSkillIds: string[];
+	/** Updates the Task selection while leaving the menu open for more choices. */
+	onSelectionChange: (skillIds: string[]) => void;
+	/** Mounted Workspace skills are visible but cannot be changed here. */
+	workspaceSkillsLocked: boolean;
+};
+
+type ComposerPermissionDropdownProps = {
+	/** Current file mutation policy for the next Task. */
+	fileAccess: CreateTaskRequest["fileAccess"];
+	/** Current command execution policy for the next Task. */
+	commandExecution: CreateTaskRequest["commandExecution"];
+	/** Updates file access independently of command execution. */
+	onFileAccessChange: (access: CreateTaskRequest["fileAccess"]) => void;
+	/** Updates command execution independently of file access. */
+	onCommandExecutionChange: (
+		permission: CreateTaskRequest["commandExecution"],
+	) => void;
+};
+
+/**
+ * Preserves the compact Skill picker while delegating focus and dismissal to Dropdown.
+ * @example
+ * <ComposerSkillDropdown availableSkills={skills} selectedSkillIds={ids} onSelectionChange={setIds} workspaceSkillsLocked={false} />
+ */
+const ComposerSkillDropdown = ({
+	availableSkills,
+	selectedSkillIds,
+	onSelectionChange,
+	workspaceSkillsLocked,
+}: ComposerSkillDropdownProps) => {
+	const { t } = useTranslation();
+	return (
+		<DropdownMenu
+			trigger={
+				<Dropdown.Trigger
+					aria-label={t("workspace.mountedSkillCount", {
+						count: workspaceSkillsLocked
+							? availableSkills.length
+							: selectedSkillIds.length,
+					})}
+					className="flex h-8 items-center gap-xs rounded-md px-sm text-caption-sm text-charcoal hover:bg-surface-soft"
+					type="button"
+				>
+					<Puzzle aria-hidden="true" className="size-3.5" />
+					<span>
+						{workspaceSkillsLocked
+							? availableSkills.length
+							: selectedSkillIds.length}
+					</span>
+				</Dropdown.Trigger>
+			}
+			offset={8}
+			placement="top start"
+			className="w-64 max-w-[calc(100vw-24px)] overflow-hidden rounded-lg border border-hairline bg-canvas p-sm shadow-[0_16px_40px_rgba(0,0,0,0.12)]"
+			aria-label={t("workspace.skillSelection")}
+			menuClassName="max-h-64 overflow-y-auto p-0"
+			selectionMode="multiple"
+			selectedKeys={
+				workspaceSkillsLocked
+					? availableSkills.map((skill) => skill.id)
+					: selectedSkillIds
+			}
+			onSelectionChange={(keys) => {
+				if (!workspaceSkillsLocked)
+					onSelectionChange(
+						keys === "all"
+							? availableSkills.map((skill) => skill.id)
+							: Array.from(keys, String),
+					);
+			}}
+			closeOnSelect={false}
+		>
+			{availableSkills.length > 0 ? (
+				availableSkills.map((skill) => {
+					const selected =
+						workspaceSkillsLocked || selectedSkillIds.includes(skill.id);
+					return (
+						<Dropdown.Item
+							id={skill.id}
+							aria-label={skill.displayName}
+							textValue={skill.displayName}
+							className="flex w-full items-start gap-sm rounded-md px-md py-sm text-left hover:bg-surface-soft disabled:cursor-default"
+							isDisabled={workspaceSkillsLocked}
+							key={skill.id}
+						>
+							<Puzzle aria-hidden="true" className="mt-xs size-4" />
+							<span className="min-w-0 flex-1">
+								<span className="block truncate text-body-sm font-medium">
+									{skill.displayName}
+								</span>
+								<span className="line-clamp-2 text-caption-sm text-body">
+									{skill.description}
+								</span>
+							</span>
+							{selected ? (
+								<CircleCheckFill aria-hidden="true" className="size-4" />
+							) : null}
+						</Dropdown.Item>
+					);
+				})
+			) : (
+				<Dropdown.Item
+					id="empty"
+					textValue={t("workspace.noSkills")}
+					isDisabled
+					className="px-md py-sm text-caption-sm text-mute"
+				>
+					{t("workspace.noSkills")}
+				</Dropdown.Item>
+			)}
+		</DropdownMenu>
+	);
+};
+
+/**
+ * Keeps both permission groups in one anchored menu so users can configure a Task together.
+ * @example
+ * <ComposerPermissionDropdown fileAccess={access} commandExecution={execution} onFileAccessChange={setAccess} onCommandExecutionChange={setExecution} />
+ */
+const ComposerPermissionDropdown = ({
+	fileAccess,
+	commandExecution,
+	onFileAccessChange,
+	onCommandExecutionChange,
+}: ComposerPermissionDropdownProps) => {
+	const { t } = useTranslation();
+	return (
+		<div className="hidden min-[1040px]:block">
+			<DropdownMenu
+				trigger={
+					<Dropdown.Trigger
+						aria-label={t("workspace.permission")}
+						className="flex h-8 items-center gap-xs rounded-md px-sm text-caption-sm text-body outline-none hover:bg-surface-soft focus-visible:ring-2 focus-visible:ring-focus-ring"
+						type="button"
+					>
+						<ShieldCheck aria-hidden="true" className="size-3.5" />
+						{t(
+							fileAccess === "allow_edits"
+								? "workspace.permission"
+								: "workspace.permissionReadOnly",
+						)}
+					</Dropdown.Trigger>
+				}
+				offset={8}
+				placement="top end"
+				className="w-64 max-w-[calc(100vw-24px)] overflow-y-auto rounded-lg border border-hairline bg-canvas p-sm shadow-[0_16px_40px_rgba(0,0,0,0.12)]"
+				closeOnSelect={false}
+				menuClassName="p-0"
+				aria-label={t("workspace.permissionSelection")}
+			>
+				<Dropdown.Section selectionMode="single" selectedKeys={[fileAccess]}>
+					<Header className="px-md pb-xs text-[11px] font-medium uppercase text-mute">
+						{t("workspace.filePermission")}
+					</Header>
+					{(["read_only", "allow_edits"] as const).map((access) => (
+						<Dropdown.Item
+							aria-label={t(
+								access === "read_only"
+									? "workspace.permissionReadOnly"
+									: "workspace.permissionAllowEdits",
+							)}
+							id={access}
+							onAction={() => onFileAccessChange(access)}
+							textValue={t(
+								access === "read_only"
+									? "workspace.permissionReadOnly"
+									: "workspace.permissionAllowEdits",
+							)}
+							className="flex w-full items-center justify-between rounded-md px-md py-sm text-left text-body-sm hover:bg-surface-soft"
+							key={access}
+						>
+							{t(
+								access === "read_only"
+									? "workspace.permissionReadOnly"
+									: "workspace.permissionAllowEdits",
+							)}
+							{fileAccess === access ? (
+								<CircleCheckFill aria-hidden="true" className="size-4" />
+							) : null}
+						</Dropdown.Item>
+					))}
+				</Dropdown.Section>
+				<Dropdown.Section
+					selectionMode="single"
+					selectedKeys={[commandExecution]}
+				>
+					<Header className="mt-xs border-t border-hairline px-md pb-xs pt-sm text-[11px] font-medium uppercase text-mute">
+						{t("workspace.commandPermission")}
+					</Header>
+					{(["deny", "ask", "allow"] as const).map((permission) => (
+						<Dropdown.Item
+							aria-label={t(`workspace.commandPermissionOption.${permission}`)}
+							id={permission}
+							onAction={() => onCommandExecutionChange(permission)}
+							textValue={t(`workspace.commandPermissionOption.${permission}`)}
+							className="flex w-full items-center justify-between rounded-md px-md py-sm text-left text-body-sm hover:bg-surface-soft"
+							key={permission}
+						>
+							{t(`workspace.commandPermissionOption.${permission}`)}
+							{commandExecution === permission ? (
+								<CircleCheckFill aria-hidden="true" className="size-4" />
+							) : null}
+						</Dropdown.Item>
+					))}
+				</Dropdown.Section>
+			</DropdownMenu>
+		</div>
+	);
+};
+
+export { ComposerPermissionDropdown, ComposerSkillDropdown };

--- a/src/components/share/composer-dropdowns.tsx
+++ b/src/components/share/composer-dropdowns.tsx
@@ -91,7 +91,7 @@ const ComposerSkillDropdown = ({
 							id={skill.id}
 							aria-label={skill.displayName}
 							textValue={skill.displayName}
-							className="flex w-full items-start gap-sm rounded-md px-md py-sm text-left hover:bg-surface-soft disabled:cursor-default"
+							className="flex h-18 w-full shrink-0 items-start gap-sm overflow-hidden rounded-md px-md py-sm text-left hover:bg-surface-soft disabled:cursor-default"
 							isDisabled={workspaceSkillsLocked}
 							key={skill.id}
 						>

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,8 +1,9 @@
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 import {
 	Dropdown,
 	type DropdownPopoverProps,
 	Header,
+	type DropdownMenuProps as HeroDropdownMenuProps,
 	Label,
 	Separator,
 } from "@heroui/react";
@@ -27,7 +28,12 @@ type DropdownMenuItemProps<T extends string> = {
 	testId?: string;
 };
 
-type DropdownMenuProps<T extends string> = {
+type DropdownMenuProps<T extends string> = Pick<
+	HeroDropdownMenuProps<object>,
+	"selectionMode" | "selectedKeys" | "onSelectionChange" | "aria-label"
+> & {
+	/** Rich menu items or sections for selection menus; replaces the action item shorthand. */
+	children?: ReactNode;
 	/** Additional classes applied to the floating popover. */
 	className?: string;
 	/** Whether the menu closes after an item is selected. Defaults to true. */
@@ -37,13 +43,13 @@ type DropdownMenuProps<T extends string> = {
 	/** Additional classes applied to every menu item. */
 	itemClassName?: string;
 	/** Business actions rendered by the menu. */
-	items: readonly DropdownMenuItemProps<T>[];
+	items?: readonly DropdownMenuItemProps<T>[];
 	/** Additional classes applied to the menu list. */
 	menuClassName?: string;
 	/** Distance in pixels between the trigger and popover. Defaults to 4. */
 	offset?: DropdownPopoverProps["offset"];
 	/** Receives the selected business action for centralized dispatch. */
-	onAction: (action: T) => void;
+	onAction?: (action: T) => void;
 	/** Preferred popover placement. Defaults to bottom start. */
 	placement?: DropdownPopoverProps["placement"];
 	/** Pressable element that opens the menu, such as a HeroUI Button. */
@@ -51,7 +57,8 @@ type DropdownMenuProps<T extends string> = {
 };
 
 /**
- * Renders a constrained business action menu with translated labels and stable action identifiers.
+ * Shares anchored menu behavior across action menus and rich selection menus.
+ * Existing item descriptors remain available; children support descriptions and independent selection sections.
  *
  * @example
  * <DropdownMenu
@@ -61,11 +68,16 @@ type DropdownMenuProps<T extends string> = {
  * />
  */
 const DropdownMenu = <T extends string>({
+	children,
+	"aria-label": ariaLabel,
+	selectionMode,
+	selectedKeys,
+	onSelectionChange,
 	className,
 	closeOnSelect = true,
 	headerKey,
 	itemClassName,
-	items,
+	items = [],
 	menuClassName,
 	offset = 4,
 	onAction,
@@ -104,7 +116,7 @@ const DropdownMenu = <T extends string>({
 				<Dropdown.SubmenuTrigger key={item.id}>
 					{menuItem}
 					<Dropdown.Popover>
-						<Dropdown.Menu onAction={(key) => onAction(key as T)}>
+						<Dropdown.Menu onAction={(key) => onAction?.(key as T)}>
 							{item.children.map((child) => (
 								<Dropdown.Item
 									key={child.id}
@@ -134,21 +146,26 @@ const DropdownMenu = <T extends string>({
 				placement={placement}
 			>
 				<Dropdown.Menu
+					aria-label={ariaLabel}
+					selectionMode={selectionMode}
+					selectedKeys={selectedKeys}
+					onSelectionChange={onSelectionChange}
 					className={menuClassName}
 					onAction={(key) => {
 						const action = key as T;
-						onAction(action);
+						onAction?.(action);
 					}}
 					shouldCloseOnSelect={closeOnSelect}
 				>
-					{headerKey ? (
-						<Dropdown.Section>
-							<Header>{t(headerKey)}</Header>
-							{renderedItems}
-						</Dropdown.Section>
-					) : (
-						renderedItems
-					)}
+					{children ??
+						(headerKey ? (
+							<Dropdown.Section>
+								<Header>{t(headerKey)}</Header>
+								{renderedItems}
+							</Dropdown.Section>
+						) : (
+							renderedItems
+						))}
 				</Dropdown.Menu>
 			</Dropdown.Popover>
 		</Dropdown>

--- a/src/pages/workspace/components/composer.test.tsx
+++ b/src/pages/workspace/components/composer.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { expect, it, vi } from "vitest";
+import { Composer } from "./composer";
+
+const SKILLS = ["Review", "Testing"].map((name) => ({
+	id: name,
+	folderName: name,
+	displayName: name,
+	description: `${name} skill`,
+	sourceType: "platform" as const,
+	sourcePath: null,
+	createdAtMs: 0,
+	updatedAtMs: 0,
+}));
+
+/**
+ * Keeps the real Composer controls available without native environment queries.
+ * @example renderComposer(true, SKILLS);
+ */
+const renderComposer = (
+	workspaceSkillsLocked = false,
+	availableSkills = SKILLS,
+) => {
+	const onSubmit = vi.fn().mockResolvedValue(undefined);
+	render(
+		<Composer
+			agentKinds={["codex"]}
+			agentProcesses={{
+				codex: true,
+				claude: false,
+				opencode: false,
+				workbuddy: false,
+			}}
+			environmentRuntimes={{
+				codex: { status: "checking" },
+				claude: { status: "checking" },
+				opencode: { status: "checking" },
+				workbuddy: { status: "checking" },
+			}}
+			availableSkills={availableSkills}
+			workspaceSkillsLocked={workspaceSkillsLocked}
+			isSubmitting={false}
+			onSubmit={onSubmit}
+		/>,
+	);
+	return onSubmit;
+};
+
+it("keeps skill multiselection when dismissed and submits the selected skills", async () => {
+	const user = userEvent.setup();
+	const onSubmit = renderComposer();
+	await user.click(screen.getByRole("button", { name: "0 个技能" }));
+	await user.click(screen.getByRole("menuitemcheckbox", { name: "Review" }));
+	await user.click(screen.getByRole("menuitemcheckbox", { name: "Testing" }));
+	await user.click(screen.getByRole("menuitemcheckbox", { name: "Review" }));
+	await user.keyboard("{Escape}");
+	await waitFor(() =>
+		expect(screen.getByRole("button", { name: "1 个技能" })).toHaveFocus(),
+	);
+	await user.click(screen.getByRole("button", { name: "1 个技能" }));
+	expect(
+		screen.getByRole("menuitemcheckbox", { name: "Testing" }),
+	).toHaveAttribute("aria-checked", "true");
+	await user.click(
+		screen.getByRole("textbox", { name: "任务内容", hidden: true }),
+	);
+	expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+	await user.type(screen.getByRole("textbox", { name: "任务内容" }), "/");
+	await user.click(screen.getByRole("option", { name: /Codex/ }));
+	await user.type(
+		screen.getByRole("textbox", { name: "任务内容" }),
+		"Review code",
+	);
+	await user.click(screen.getByRole("button", { name: "发送任务" }));
+	expect(onSubmit).toHaveBeenCalledWith(
+		expect.objectContaining({ skillIds: ["Testing"] }),
+	);
+});
+
+it("shows mounted skills as selected and locked", async () => {
+	const user = userEvent.setup();
+	renderComposer(true);
+	await user.click(screen.getByRole("button", { name: "2 个技能" }));
+	const skill = screen.getByRole("menuitemcheckbox", { name: "Review" });
+	expect(skill).toHaveAttribute("aria-checked", "true");
+	expect(skill).toHaveAttribute("aria-disabled", "true");
+	await user.click(skill);
+	expect(skill).toHaveAttribute("aria-checked", "true");
+});
+
+it("shows an empty skill menu that can be dismissed with Escape", async () => {
+	const user = userEvent.setup();
+	renderComposer(false, []);
+	await user.click(screen.getByRole("button", { name: "0 个技能" }));
+	expect(screen.getByText("暂无可用技能")).toBeVisible();
+	await user.keyboard("{Escape}");
+	expect(screen.queryByText("暂无可用技能")).not.toBeInTheDocument();
+});

--- a/src/pages/workspace/components/composer.tsx
+++ b/src/pages/workspace/components/composer.tsx
@@ -4,12 +4,14 @@ import {
 	ChevronDown,
 	CircleCheckFill,
 	Paperclip,
-	Puzzle,
-	ShieldCheck,
 } from "@gravity-ui/icons";
 import { cn } from "cnfast";
 import { useTranslation } from "react-i18next";
 import { AgentIcon } from "@/components/share/agent-icon";
+import {
+	ComposerPermissionDropdown,
+	ComposerSkillDropdown,
+} from "@/components/share/composer-dropdowns";
 import type {
 	AgentKind,
 	AgentProcessStates,
@@ -52,6 +54,7 @@ type ComposerProps = {
 
 /**
  * Keeps task composition state together while the page owns environment loading and results.
+ * Dropdown primitives manage dismissal and focus without changing the compact toolbar styling.
  *
  * @example
  * <Composer
@@ -83,8 +86,6 @@ const Composer = ({
 	const [commandExecution, setCommandExecution] =
 		useState<CreateTaskRequest["commandExecution"]>("allow");
 	const [isAgentMenuOpen, setIsAgentMenuOpen] = useState(false);
-	const [isSkillMenuOpen, setIsSkillMenuOpen] = useState(false);
-	const [isPermissionMenuOpen, setIsPermissionMenuOpen] = useState(false);
 	const isSlashAutocompleteOpen =
 		isAgentMenuOpen || prompt.trimEnd().endsWith("/");
 
@@ -247,160 +248,20 @@ const Composer = ({
 								<ChevronDown aria-hidden="true" className="size-3" />
 							</button>
 
-							<div className="relative">
-								<button
-									aria-expanded={isSkillMenuOpen}
-									aria-label={t("workspace.mountedSkillCount", {
-										count: workspaceSkillsLocked
-											? availableSkills.length
-											: selectedSkillIds.length,
-									})}
-									className="flex h-8 items-center gap-xs rounded-md px-sm text-caption-sm text-charcoal hover:bg-surface-soft"
-									onClick={() => setIsSkillMenuOpen((open) => !open)}
-									type="button"
-								>
-									<Puzzle aria-hidden="true" className="size-3.5" />
-									<span>
-										{workspaceSkillsLocked
-											? availableSkills.length
-											: selectedSkillIds.length}
-									</span>
-								</button>
-								{isSkillMenuOpen ? (
-									<div
-										aria-label={t("workspace.skillSelection")}
-										className="absolute bottom-[calc(100%+8px)] left-0 max-h-64 w-64 overflow-y-auto rounded-lg border border-hairline bg-canvas p-sm shadow-[0_16px_40px_rgba(0,0,0,0.12)]"
-										role="listbox"
-									>
-										{availableSkills.length > 0 ? (
-											availableSkills.map((skill) => {
-												const selected =
-													workspaceSkillsLocked ||
-													selectedSkillIds.includes(skill.id);
-												return (
-													<button
-														aria-selected={selected}
-														className="flex w-full items-start gap-sm rounded-md px-md py-sm text-left hover:bg-surface-soft disabled:cursor-default"
-														disabled={workspaceSkillsLocked}
-														key={skill.id}
-														onClick={() =>
-															setSelectedSkillIds((current) =>
-																current.includes(skill.id)
-																	? current.filter((id) => id !== skill.id)
-																	: [...current, skill.id],
-															)
-														}
-														role="option"
-														type="button"
-													>
-														<Puzzle
-															aria-hidden="true"
-															className="mt-xs size-4"
-														/>
-														<span className="min-w-0 flex-1">
-															<span className="block truncate text-body-sm font-medium">
-																{skill.displayName}
-															</span>
-															<span className="line-clamp-2 text-caption-sm text-body">
-																{skill.description}
-															</span>
-														</span>
-														{selected ? (
-															<CircleCheckFill
-																aria-hidden="true"
-																className="size-4"
-															/>
-														) : null}
-													</button>
-												);
-											})
-										) : (
-											<p className="px-md py-sm text-caption-sm text-mute">
-												{t("workspace.noSkills")}
-											</p>
-										)}
-									</div>
-								) : null}
-							</div>
+							<ComposerSkillDropdown
+								availableSkills={availableSkills}
+								selectedSkillIds={selectedSkillIds}
+								onSelectionChange={setSelectedSkillIds}
+								workspaceSkillsLocked={workspaceSkillsLocked}
+							/>
 						</div>
 						<div className="flex shrink-0 items-center gap-md">
-							<div className="relative hidden min-[1040px]:block">
-								<button
-									aria-expanded={isPermissionMenuOpen}
-									aria-label={t("workspace.permission")}
-									className="flex h-8 items-center gap-xs rounded-md px-sm text-caption-sm text-body outline-none hover:bg-surface-soft focus-visible:ring-2 focus-visible:ring-focus-ring"
-									onClick={() => setIsPermissionMenuOpen((open) => !open)}
-									type="button"
-								>
-									<ShieldCheck aria-hidden="true" className="size-3.5" />
-									{t(
-										fileAccess === "allow_edits"
-											? "workspace.permission"
-											: "workspace.permissionReadOnly",
-									)}
-								</button>
-								{isPermissionMenuOpen ? (
-									<fieldset
-										aria-label={t("workspace.permissionSelection")}
-										className="absolute bottom-[calc(100%+8px)] right-0 w-64 rounded-lg border border-hairline bg-canvas p-sm shadow-[0_16px_40px_rgba(0,0,0,0.12)]"
-									>
-										<p className="px-md pb-xs text-[11px] font-medium uppercase text-mute">
-											{t("workspace.filePermission")}
-										</p>
-										{(["read_only", "allow_edits"] as const).map((access) => (
-											<button
-												aria-label={t(
-													access === "read_only"
-														? "workspace.permissionReadOnly"
-														: "workspace.permissionAllowEdits",
-												)}
-												aria-selected={fileAccess === access}
-												className="flex w-full items-center justify-between rounded-md px-md py-sm text-left text-body-sm hover:bg-surface-soft"
-												key={access}
-												onClick={() => setFileAccess(access)}
-												role="option"
-												type="button"
-											>
-												{t(
-													access === "read_only"
-														? "workspace.permissionReadOnly"
-														: "workspace.permissionAllowEdits",
-												)}
-												{fileAccess === access ? (
-													<CircleCheckFill
-														aria-hidden="true"
-														className="size-4"
-													/>
-												) : null}
-											</button>
-										))}
-										<p className="mt-xs border-t border-hairline px-md pb-xs pt-sm text-[11px] font-medium uppercase text-mute">
-											{t("workspace.commandPermission")}
-										</p>
-										{(["deny", "ask", "allow"] as const).map((permission) => (
-											<button
-												aria-label={t(
-													`workspace.commandPermissionOption.${permission}`,
-												)}
-												aria-selected={commandExecution === permission}
-												className="flex w-full items-center justify-between rounded-md px-md py-sm text-left text-body-sm hover:bg-surface-soft"
-												key={permission}
-												onClick={() => setCommandExecution(permission)}
-												role="option"
-												type="button"
-											>
-												{t(`workspace.commandPermissionOption.${permission}`)}
-												{commandExecution === permission ? (
-													<CircleCheckFill
-														aria-hidden="true"
-														className="size-4"
-													/>
-												) : null}
-											</button>
-										))}
-									</fieldset>
-								) : null}
-							</div>
+							<ComposerPermissionDropdown
+								fileAccess={fileAccess}
+								commandExecution={commandExecution}
+								onFileAccessChange={setFileAccess}
+								onCommandExecutionChange={setCommandExecution}
+							/>
 							<button
 								aria-label={t("workspace.sendTask")}
 								className="grid size-8 place-items-center rounded-md bg-primary text-on-primary outline-none transition-transform enabled:active:scale-95 disabled:cursor-not-allowed disabled:bg-hairline-strong"

--- a/src/pages/workspace/index.test.tsx
+++ b/src/pages/workspace/index.test.tsx
@@ -380,8 +380,11 @@ describe("WorkspacePage", () => {
 		render(<WorkspacePage />);
 
 		await user.click(screen.getByRole("button", { name: "可写入工作区" }));
-		await user.click(screen.getByRole("option", { name: "只读文件" }));
-		await user.click(screen.getByRole("option", { name: "禁止执行命令" }));
+		await user.click(screen.getByRole("menuitemradio", { name: "只读文件" }));
+		await user.click(
+			screen.getByRole("menuitemradio", { name: "禁止执行命令" }),
+		);
+		await user.keyboard("{Escape}");
 		await user.type(screen.getByRole("textbox", { name: "任务内容" }), "/");
 		await user.click(await screen.findByRole("option", { name: /Codex/ }));
 		await user.type(


### PR DESCRIPTION
## Summary

Replace the Composer skill and permission overlays with shared DropdownMenu components. The wrapper now accepts rich content and controlled selection while retaining the existing action-item API. Skill multiselection, locked Workspace mounts, and independent permission groups retain their behavior, with Escape and outside-click dismissal.

Keep skill rows at a fixed 72px height without flex compression, preserving single-line titles and two-line description ellipsis to prevent overlapping text in long lists.

Raise the frontend asset budgets to 5.2 MB total and 3.5 MB JavaScript to accommodate Markdown math and offline fonts already present on main, with roughly 7% headroom over measured sizes.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm check`
- [x] `pnpm test` — 234 tests passed
- [x] `pnpm build`
- [x] `node --test .github/scripts/benchmark.test.mjs` — 11 tests passed, including budget boundaries
- Rust checks: not applicable; no backend changes
- Browser verification with 12 skills containing long descriptions: fixed row heights, ellipsis, and no overlapping text

## Risk review

- [x] No new system permission or capability is required
- [x] Sensitive Agent data is not logged, persisted, or exported unexpectedly
- [x] macOS and Windows behavior has been considered; native Windows execution was not performed
- [x] Tests cover new behavior and relevant failure paths

## Screenshots or logs

Local workflow benchmark on macOS with Node 24 and pnpm 11.10.0 compared main (`c84cb58`) with the Composer changes (`3495232`). Each revision was built three times; dependency downloads were excluded.

| Metric | Main | Composer changes | Updated limit | Result |
| --- | ---: | ---: | ---: | --- |
| Median build time | 7.036 s | 6.370 s | 9.147 s | PASS |
| Total assets | 4,858,503 B | 4,860,384 B | 5,200,000 B | PASS |
| JavaScript | 3,266,113 B | 3,267,913 B | 3,500,000 B | PASS |
| CSS | 487,136 B | 487,217 B | 535,849.6 B | PASS |

The original run failed the old asset budgets, as did the latest main workflow. The recorded measurements were re-evaluated successfully against the updated thresholds; build timing may differ on the Ubuntu CI runner.
